### PR TITLE
fixes a spec that was actually not testing the right thing

### DIFF
--- a/spec/requests/rpc_spec.rb
+++ b/spec/requests/rpc_spec.rb
@@ -89,12 +89,16 @@ RSpec.describe "RPC", type: :request do
     end
 
     it "should 404 if the method is not supported" do
+      address = '0x91b51c173a4bDAa1A60e234fC3f705A16D228740'
+      endpoint = create(:endpoint, account: account)
+
       post "/rpc", params: {
         method: "unsupported_method",
+        params: [address],
       },
       headers: {
         'X-QUICKNODE-ID': account.quicknode_id,
-        'X-INSTANCE-ID': 'foobar',
+        'X-INSTANCE-ID': endpoint.quicknode_id,
         'X-QN-CHAIN': 'ethereum',
         'X-QN-NETWORK': 'mainet',
       }


### PR DESCRIPTION
Since we were not passing a legit endpoint-ID, the controller method was throwing a 404 for that reason, not because it did not recognize the method name. This PR fixes this and makes sure we make the HTTP call with correct endpoint ID header and correct params.