### PR TITLE
Fixes a bug which prevented from deprovisioning and account with no endpoints

### DIFF
--- a/app/controllers/provisioning_controller.rb
+++ b/app/controllers/provisioning_controller.rb
@@ -70,7 +70,6 @@ class ProvisioningController < ApplicationController
 
   def deprovision
     render_404 and return unless @account
-    render_404 and return unless @endpoint
 
     @account.endpoints.each(&:discard)
     @account.discard

--- a/spec/requests/provisioning_spec.rb
+++ b/spec/requests/provisioning_spec.rb
@@ -169,14 +169,6 @@ RSpec.describe "Provisionings", type: :request do
       expect(response).to have_http_status(404)
     end
 
-    it "should 404 if the endpoint does not exist" do
-      delete "/deprovision", params: {
-        "quicknode-id": account.quicknode_id,
-        "endpoint-id": "does-not-exist",
-      }, headers: { "Authorization" => credentials }
-      expect(response).to have_http_status(404)
-    end
-
     it "should discard the account and all its endpoints" do
       endpoint = create(:endpoint, account: account)
       create(:endpoint, account: account)


### PR DESCRIPTION
It's possible to deactivate all endpoints for an account. In this case, the account has no endpoints and the deprovision call 404s. This PR fixes that bug.